### PR TITLE
feat: add alias `mu` for `emerge -u @world`

### DIFF
--- a/profile/alias-short.zsh
+++ b/profile/alias-short.zsh
@@ -63,6 +63,7 @@ alias ls='ls --color=auto --classify --human-readable --group-directories-first 
 alias m='sudo -E emerge'
 alias mmodule='m @module-rebuild'
 alias mrebuild='m --backtrack=30 --with-bdeps=y @live-rebuild @module-rebuild @preserved-rebuild'
+alias mu='m -u @world'
 alias mudn='m -uDN @world'
 alias mudnb='mudn --backtrack=30'
 alias mudnbw='mudn --backtrack=30 --with-bdeps=y'


### PR DESCRIPTION
依存関係まで更新してしまうと壊れてしまうことが多発するので、
実用的には明示的な`@world`までの更新で十分なことに気が付き始めました。