### PR TITLE
feat: corepackでnpmを管理しないようにする

### DIFF
--- a/bin/yarn-install-world
+++ b/bin/yarn-install-world
@@ -5,8 +5,8 @@ world='
 prettier
 '
 
-# corepackでnpmとyarnを管理する。
-corepack enable --install-directory ~/.local/bin npm yarn pnpm
+# corepackでyarnとpnpmを管理する。
+corepack enable --install-directory ~/.local/bin yarn pnpm
 # グローバルでは勝手にマイグレーションを行わないようにyarn classicを利用する。
 corepack prepare yarn@1 --activate
 


### PR DESCRIPTION
corepackでnpmを管理してしまうと、
npmを使っている素朴なプロジェクトでpackage.jsonの書き換えがいちいち行われてしまう。
npmはNode.jsにデフォルトで入っているのでcorepackで管理する意義も薄い。
