### PR TITLE
fix(gh-single-merge): Remove -x option from set command

### DIFF
--- a/bin/gh-single-merge
+++ b/bin/gh-single-merge
@@ -1,5 +1,5 @@
 #!/bin/zsh
-set -eux
+set -eu
 
 # To make Pull Requests easily in personal development repositories, single commits are merged in a messy way.
 


### PR DESCRIPTION
全部traceするのは量が多すぎて見づらい。
特に日本語をちゃんと処理できない出力も多い。
