### PR TITLE
fix: add workaround for trashy completion error

### DIFF
--- a/profile/completion.zsh
+++ b/profile/completion.zsh
@@ -42,3 +42,10 @@ generate-completion-file-by-command() {
 }
 
 generate-completion-file-by-command 'poetry' 'poetry completions zsh'
+
+# trashyの補完がエラーになるので雑に回避。
+# TODO: 調査して問題を起こしているところにバグ報告をする。
+function _trash() {
+  _files
+}
+compdef _trash trash


### PR DESCRIPTION
Avoids errors with trashy command completion by defining a simple _trash function using _files.
TODO: investigate and report the underlying issue.
