### PR TITLE
fix!: installスクリプトを削除

### DIFF
--- a/install
+++ b/install
@@ -1,5 +1,0 @@
-#!/usr/bin/env zsh
-set -eu
-
-cd ~
-ln -sfv .zsh.d/.zshrc .


### PR DESCRIPTION
dotfilesの更新によって、
`install` スクリプトで配置することが必須ではなくなったので削除。
もともと別に大したことをやっていたわけではなかった。
