### PR TITLE
feat(github/label-presets): ラベルプリセットの整理

### DIFF
--- a/share/github/label-presets.json
+++ b/share/github/label-presets.json
@@ -1,82 +1,59 @@
 [
   {
-    "name": "duplicate",
-    "color": "ededed",
-    "description": "This issue or Pull Request already exists"
-  },
-  {
-    "name": "help wanted",
-    "color": "e99695",
-    "description": "Extra attention is needed"
-  },
-  {
-    "name": "good first issue",
-    "color": "7057ff",
-    "description": "Good for newcomers",
-    "aliases": [
-      "beginner-friendly",
-      "beginner",
-      "good-starter-issue",
-      "good for beginner",
-      "Good for beginners",
-      "starter-issue",
-      "starter"
-    ]
-  },
-  {
     "name": "Priority: Critical",
-    "color": "ee0701"
+    "color": "ee0701",
+    "aliases": ["P0", "Priority: P0"]
   },
   {
     "name": "Priority: High",
-    "color": "d93f0b"
+    "color": "d93f0b",
+    "aliases": ["P1", "Priority: P1"]
   },
   {
     "name": "Priority: Medium",
-    "color": "fbca04"
+    "color": "fbca04",
+    "aliases": ["P2", "Priority: P2"]
   },
   {
     "name": "Priority: Low",
-    "color": "0e8a16"
-  },
-  {
-    "name": "Status: Abandoned",
-    "color": "000000",
-    "description": "The issue or Pull Request is wontfix",
-    "aliases": ["wontfix", "invalid"]
+    "color": "0e8a16",
+    "aliases": ["P3", "Priority: P3"]
   },
   {
     "name": "Status: Blocked",
     "color": "ee0701",
-    "description": "Progress on the issue is Blocked",
+    "description": "Progress on it is Blocked",
     "aliases": ["blocked"]
-  },
-  {
-    "name": "Status: In Progress",
-    "description": "Work in Progress",
-    "color": "cccccc"
-  },
-  {
-    "name": "Status: Proposal",
-    "color": "d4c5f9",
-    "description": "Request for comments",
-    "aliases": ["idea", "Idea", "proposal", "Proposal", "discussion"]
   },
   {
     "name": "Status: PR Welcome",
     "color": "2E7733",
     "description": "Welcome to Pull Request",
-    "aliases": ["Patch Welcome", "Status: Ready for PR"]
-  },
-  {
-    "name": "Status: Review Needed",
-    "color": "fbca04",
-    "description": "Request for review comments"
+    "aliases": [
+      "Good for beginners",
+      "Patch Welcome",
+      "beginner",
+      "beginner-friendly",
+      "good first issue",
+      "good for beginner",
+      "good-starter-issue",
+      "starter",
+      "starter-issue"
+    ]
   },
   {
     "name": "Status: Need More Info",
     "color": "F9C90A",
-    "description": "Lacks enough info to make progress"
+    "description": "Lacks enough info to make progress",
+    "aliases": [
+      "Idea",
+      "Proposal",
+      "discussion",
+      "help wanted",
+      "idea",
+      "proposal",
+      "question"
+    ]
   },
   {
     "name": "Type: Breaking Change",
@@ -88,25 +65,25 @@
     "name": "Type: Bug",
     "color": "ee0701",
     "description": "Bug or Bug fixes",
-    "aliases": ["bug"]
+    "aliases": ["bug", "fix", "fixed"]
   },
   {
     "name": "Type: Documentation",
     "color": "0e8a16",
-    "description": "Documentation only changes",
-    "aliases": ["documents", "document"]
+    "description": "Change or improvement in documentation or comment",
+    "aliases": ["doc", "docs", "document", "documentation"]
   },
   {
     "name": "Type: Feature",
     "color": "1d76db",
     "description": "New Feature",
-    "aliases": ["enhancement"]
+    "aliases": ["enhancement", "feat", "feature", "perf"]
   },
   {
     "name": "Type: Refactoring",
     "color": "fbca04",
-    "description": "A code change that neither fixes a bug nor adds a feature",
-    "aliases": ["refactor"]
+    "description": "Includes cleanup",
+    "aliases": ["refactor", "style"]
   },
   {
     "name": "Type: Testing",
@@ -115,22 +92,10 @@
     "aliases": ["test", "testing"]
   },
   {
-    "name": "Type: Maintenance",
-    "color": "abd406",
-    "description": "Repository Maintenance",
-    "aliases": ["greenkeeper", "maintenance"]
-  },
-  {
     "name": "Type: CI",
     "color": "ffd412",
     "description": "Changes to CI configuration files and scripts",
-    "aliases": ["travis", "ci", "circleci"]
-  },
-  {
-    "name": "Type: Question",
-    "color": "cc317c",
-    "description": "Further information is requested",
-    "aliases": ["question"]
+    "aliases": ["ci", "continuous-integration"]
   },
   {
     "name": "Type: Security",
@@ -142,18 +107,18 @@
     "name": "Type: Dependencies",
     "color": "0366d6",
     "description": "Dependency issues or Changes to dependency files",
-    "aliases": ["dependencies"]
+    "aliases": ["build", "dep", "dependencies", "deps", "greenkeeper"]
   },
   {
     "name": "Type: Meta",
     "color": "BFD4F2",
-    "description": "Type: Meta - Related to repository itself",
+    "description": "Related to repository outside",
     "aliases": ["meta"]
   },
   {
     "name": "Type: Release",
     "color": "5319E7",
     "description": "Related to release process",
-    "aliases": ["meta"]
+    "aliases": ["release", "release-note"]
   }
 ]


### PR DESCRIPTION
GitHub自体のissue管理やProjectsを考えると不要なものが多い。
いつも選ぶのが悩ましかったのでなるべく削減してシンプルにする。
