### PR TITLE
fix: `.profile`を一々読み込まない

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,3 @@
-typeset -U path PATH
-source ~/.profile
 export PATH="$HOME/.zsh.d/bin:$PATH"
 
 if ! [ -t 0 ]; then


### PR DESCRIPTION
ファイルは基本的に削除して期待しないようにします。
