### PR TITLE
feat(clipboard): クリップボードのエラー防止

### DIFF
--- a/profile/alias-function.zsh
+++ b/profile/alias-function.zsh
@@ -7,7 +7,7 @@ alias disk-usage='sudo du --human-readable --one-file-system .|sort --human-nume
 alias docker-image-prune-month='docker image prune --all --filter until=744h'
 alias fullpath='find -L `pwd` -maxdepth 1'
 alias gcc-march-native='gcc -march=native -E -v - </dev/null 2>&1|grep cc1'
-alias git-daily='git log --all --format="%h %ai %s" --since=$(date +"%Y-%m-%d-00:00:00") --author=$(git config user.email)|xsel --clipboard --input --logfile /dev/null'
+alias git-daily='git log --all --format="%h %ai %s" --since=$(date +"%Y-%m-%d-00:00:00") --author=$(git config user.email)|to-clipboard'
 alias git-locate-pull='locate --regex "$(pwd)/.*/\.git$" --null|parallel --null --keep-order "test -d {} -a -d {}/.. && cd {}/.. && echo {}: && git -c color.diff=always pull --progress --all --keep"'
 alias git-submodule-pull='git submodule foreach "git checkout master && git pull"'
 alias grub-update='sudo grub-mkconfig -o /boot/grub/grub.cfg'
@@ -20,6 +20,20 @@ alias nix-flake-update-commit='nix flake update --commit-lock-file --option comm
 alias opusenc-speech='parallel "opusenc --speech --framesize 60 {} {.}.opus" :::'
 alias oxipng-best='parallel "oxipng --opt max --strip safe --interlace 0 --zopfli" :::'
 alias sqlite3-vacuum='locate --null "$(pwd)"|parallel --null "file"|rg "SQLite 3.x"|cut -d: -f1|parallel --verbose "sqlite3 {} \"vacuum;reindex;\""'
-alias to-clipboard='xsel --logfile /dev/null --input --clipboard'
 alias trash-clear='trash empty --before 1month'
 alias treep='tree|bat'
+
+to-clipboard() {
+  # パイプで受け取った内容をクリップボードに書き込む関数
+  # 環境に応じてxsel, wl-copy, OSC 52を使い分けます
+  local content
+  content=$(</dev/stdin)
+  if [[ -n $DISPLAY ]] && hash xsel 2>/dev/null; then
+    echo -n "$content" | xsel --clipboard --input --logfile /dev/null
+  elif [[ -n $WAYLAND_DISPLAY ]] && hash wl-copy 2>/dev/null; then
+    echo -n "$content" | wl-copy
+  else
+    local encoded=$(echo -n "$content" | base64 | tr -d '\n')
+    printf '\e]52;c;%s\a' "$encoded"
+  fi
+}


### PR DESCRIPTION
- Update clipboard functions to use xsel on X11, wl-copy/wl-paste on Wayland,
  and OSC 52 escape sequence as fallback
- Replace git-daily alias clipboard usage with new to-clipboard function
- Add to-clipboard function for flexible clipboard handling across environments
