### PR TITLE
fix(bindkey): enable emacs keybindings in zsh profile

### DIFF
--- a/profile/bindkey.zsh
+++ b/profile/bindkey.zsh
@@ -1,5 +1,7 @@
 stty stop undef
 
+bindkey -e
+
 bindkey -s '\el' '^ull\n'       # M-l to ll
 bindkey -s '^,' ''              # C-, to Nothing
 


### PR DESCRIPTION
zshは起動時に$EDITOR環境変数に文字列viが含まれているかをチェックし、
含まれていればvi modeをデフォルトにします。

`$EDITOR`の値: `/nix/store/c1hjfnzbpyy5nrqfc96vmpsasl7khlvi-editor`

ハッシュの末尾が...khlvi-editorになっており、
zshが「EDITORにviが含まれている → vi modeにしよう」と判断してしまいました。

実際の中身はemacsclientのラッパーなのに、
Nixストアのハッシュに偶然viが含まれてしまったため、
bindkey -A viins main(vi insert mode)になり、
C-a(beginning-of-line)、C-e(end-of-line)、C-d(delete-char)などの、
Emacsスタイルのキーバインドが全てself-insertに置き換わっていました。

これまでは固定のemacs値を使っていたのでemacs modeになっていました。
明示的にemacsバインディングを指定することで修正します。
