### PR TITLE
ci: GitHub Actionsなどの設定ファイルを追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,55 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# URLなどは分割困難で長過ぎることがあるためしばしば例外が許可されます。
+# あくまで指針と各種フォーマッターへの指示です。
+max_line_length = 120
+
+# デフォルトのインデントをスペースで2幅にして例外の方を設定することにします。
+# これもcheckerがインデントではないものを誤認することがあるので、
+# あくまで指針と各種フォーマッターへの指示です。
+indent_style = space
+indent_size = 2
+
+# 標準インデントが4の言語。
+[*.{cs,csx,java,kt,kts,php,py,pyi,rs}]
+indent_size = 4
+
+# 標準インデントがタブの言語。
+[{*.go,*.make,*.mk,Makefile}]
+indent_style = tab
+indent_size = unset
+
+[*.md]
+# Markdownには最後にスペース2つ入れて強制改行するシンタックスがあるので末尾のスペースを許可。
+# 注意: なるべく強制改行は使わず、意味で段落して、改行位置はクライアントのデバイスに任せるべきです。
+trim_trailing_whitespace = false
+# MarkdownはCommonMark準拠パーサーでは箇条書きリストのネストは2スペースでも動作し、
+# 番号付きリストはマーカー幅に依存するため固定値での指定は不適切です。
+# よって値を指定しません。
+indent_size = unset
+
+[*.{json,md,nix,yml,yaml}]
+# 設定やドキュメントのファイルはURLなど改行困難なものが多いため行幅制限を緩めます。
+max_line_length = 200
+
+[.env{,.*}]
+# 接続文字列やAPIキーなど長い設定値を含むため行幅制限を無効化します。
+max_line_length = off
+
+[*.bat]
+charset = latin1
+end_of_line = crlf
+
+[*.ps1]
+charset = utf-8-bom
+end_of_line = crlf
+
+[*.reg]
+charset = utf-8-bom
+end_of_line = crlf

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,50 @@
+# 出力設定
+
+## 言語
+
+AIは人間に話すときは日本語を使ってください。
+
+しかし既存のコードのコメントなどが日本語ではない場合は、
+コメント等は既存の言語に合わせてください。
+
+## 記号
+
+ASCIIに対応する全角形(Fullwidth Forms)は使用禁止。
+
+具体的には以下のような文字:
+
+- 全角括弧 `（）` → 半角 `()`
+- 全角コロン `：` → 半角 `:`
+- 全角カンマ `，` → 半角 `,`
+- 全角数字 `０-９` → 半角 `0-9`
+
+# シェルスクリプト
+
+## コーディング規約
+
+- シェルスクリプトではBashではなくZshを一貫して使用します
+- Zshの構文・機能を積極的に活用してください
+
+# プロジェクト概要
+
+このリポジトリはZshの設定ファイル群です。
+`~/.zsh.d`に`git clone`して使います。
+
+## ディレクトリ構成
+
+- `profile/`: Zshの設定ファイル群(`.zsh`拡張子)
+- `autoload/`: Zshのautoload関数
+- `bin/`: シェルスクリプト群
+- `share/`: 共有リソース
+- `.zshrc`: エントリーポイント
+
+# リポジトリ構成
+
+Codex向けの`AGENTS.md`とClaude Code向けの`CLAUDE.md`は以下のように`.github/copilot-instructions.md`のシンボリックリンクになっています。
+
+```console
+AGENTS.md -> .github/copilot-instructions.md
+CLAUDE.md -> .github/copilot-instructions.md
+```
+
+これにより各種LLM向けのドキュメントを一元管理しています。

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    open-pull-requests-limit: 20
+    labels:
+      - "Type: CI"
+      - "Type: Dependencies"
+    schedule:
+      interval: daily

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,148 @@
+日本語で記述してください。
+
+Conventional Commitsを使います。
+
+# Conventional Commits 1.0.0
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of commit messages.
+It provides an easy set of rules for creating an explicit commit history;
+which makes it easier to write automated tools on top of.
+
+The commit message should be structured as follows:
+
+---
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+---
+
+The commit contains the following structural elements, to communicate intent to the
+consumers of your library:
+
+1. **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in Semantic Versioning).
+1. **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in Semantic Versioning).
+1. **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or appends a `!` after the type/scope, introduces a breaking API change
+   (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic Versioning).
+   A BREAKING CHANGE can be part of commits of any _type_.
+1. _types_ other than `fix:` and `feat:` are allowed, for example
+   [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+   (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines))
+   recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+1. _footers_ other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to
+   [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
+
+Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE).
+A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `!` to draw attention to breaking change
+
+```
+feat!: send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `!` to draw attention to breaking change
+
+```
+feat(api)!: send an email to the customer when a product is shipped
+```
+
+### Commit message with both `!` and BREAKING CHANGE footer
+
+```
+chore!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Specification
+
+The key words
+“MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed
+   by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space.
+1. The type `feat` MUST be used when a commit adds a new feature to your application or library.
+1. The type `fix` MUST be used when a commit represents a bug fix for your application.
+1. A scope MAY be provided after a type. A scope MUST consist of a noun describing a
+   section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+1. A description MUST immediately follow the colon and space after the type/scope prefix.
+   The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+1. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+1. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+1. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of
+   a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the
+   [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+1. A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate
+   the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+1. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer
+   token/separator pair is observed.
+1. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the
+   footer.
+1. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g.,
+   _BREAKING CHANGE: environment variables now take precedence over config files_.
+1. If included in the type/scope prefix, breaking changes MUST be indicated by a
+   `!` immediately before the `:`. If `!` is used, `BREAKING CHANGE:` MAY be omitted from the footer section,
+   and the commit description SHALL be used to describe the breaking change.
+1. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: update ref docs._
+1. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+1. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+# type
+
+Must be one of the following:
+
+- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+- **ci**: Changes to our CI configuration files and scripts
+- **docs**: Documentation only changes
+- **feat**: A new feature
+- **fix**: A bug fix
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **test**: Adding missing tests or correcting existing tests

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - "Type: Release"
+
+  categories:
+    - title: Security Fixes
+      labels: ["Type: Security"]
+    - title: Breaking Changes
+      labels: ["Type: Breaking Change"]
+    - title: Features
+      labels: ["Type: Feature"]
+    - title: Bug Fixes
+      labels: ["Type: Bug"]
+    - title: Documentation
+      labels: ["Type: Documentation"]
+    - title: Refactoring
+      labels: ["Type: Refactoring"]
+    - title: Testing
+      labels: ["Type: Testing"]
+    - title: CI
+      labels: ["Type: CI"]
+    - title: Dependency Updates
+      labels: ["Type: Dependencies", "dependencies"]
+    - title: Other Changes
+      labels: ["*"]

--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -1,0 +1,21 @@
+name: Kyosei
+
+on:
+  pull_request:
+    # Only opened and synchronize to avoid duplicate reviews
+    # on the same revision from ready_for_review or reopened events.
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  workflow:
+    # Reusable workflows are constrained by the caller's permissions,
+    # so they must be explicitly declared here.
+    # Claude GitHub App manages its own token, so only minimal permissions are needed.
+    permissions:
+      contents: read # Read repository contents for checkout
+      id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
+    uses: ncaq/kyosei-action/.github/workflows/review.yml@7ee7fb3fef4b320252487576a22ed1b65793e50b # v0.3.0
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
nix-templatesリポジトリの構成を参考に、CI/CDやコード品質に関する設定を導入しました。

- `.editorconfig`: エディタ設定の統一
- `.github/copilot-instructions.md`: LLM向けプロジェクト指示の一元管理
- `.github/dependabot.yml`: GitHub Actionsの依存関係自動更新
- `.github/git-commit-instructions.md`: Gitコミットメッセージの規約と例
- `.github/release.yml`: リリースノートのカテゴリ自動分類
- `.github/workflows/kyosei.yml`: PRに対するClaude CodeによるAIコードレビュー
- `CLAUDE.md`, `AGENTS.md`: `.github/copilot-instructions.md`へのシンボリックリンク
