### PR TITLE
refactor: .mcp.jsonとGitHub MCPのための.envrcでのトークン取得処理を削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -129,32 +129,14 @@
       "Bash(zizmor:*)",
       "WebFetch",
       "WebSearch",
-      "mcp__deepwiki",
-      "mcp__github__get_commit",
-      "mcp__github__get_file_contents",
-      "mcp__github__get_label",
-      "mcp__github__get_latest_release",
-      "mcp__github__get_me",
-      "mcp__github__get_release_by_tag",
-      "mcp__github__get_tag",
-      "mcp__github__get_team_members",
-      "mcp__github__get_teams",
-      "mcp__github__issue_read",
-      "mcp__github__list_branches",
-      "mcp__github__list_commits",
-      "mcp__github__list_issue_types",
-      "mcp__github__list_issues",
-      "mcp__github__list_pull_requests",
-      "mcp__github__list_releases",
-      "mcp__github__list_tags",
-      "mcp__github__pull_request_read",
-      "mcp__github__search_code",
-      "mcp__github__search_issues",
-      "mcp__github__search_pull_requests",
-      "mcp__github__search_repositories",
-      "mcp__github__search_users",
       "mcp__plugin_nix-tasuke_nixos"
     ],
-    "deny": ["Bash(gh * delete:*)", "Bash(gh repo archive:*)", "Bash(gh repo rename:*)", "Bash(git rm:*)", "Bash(rm:*)"]
+    "deny": [
+      "Bash(gh * delete:*)",
+      "Bash(gh repo archive:*)",
+      "Bash(gh repo rename:*)",
+      "Bash(git rm:*)",
+      "Bash(rm:*)"
+    ]
   }
 }


### PR DESCRIPTION
- `.mcp.json`を削除
- `.envrc`からGitHub MCP用の`GITHUB_TOKEN`取得処理を削除
- `.claude/settings.json`から`mcp__deepwiki`や`mcp__github`関連の`allow`設定を削除

GitHub MCPやDeepWiki MCPの設定は、
ユーザのクライアント設定に委ねるべきだと思ったから設定を削除します。

nix-tasuke由来のMCPサーバの実行許可設定は、
プロジェクトがNixを利用することを前提にしているので、
プロジェクトの性質を示していると考えて残しています。

ncaq/nix-templates#183 と同様の変更です。
