### PR TITLE
fix: `$ZDOTDIR`が設定されていない環境向けにフォールバックを追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,7 @@
+# `$ZDOTDIR`が設定されていない環境では、
+# `$HOME`を今後の`$ZDOTDIR`として設定する。
+export ZDOTDIR="${ZDOTDIR:-$HOME}"
+
 export PATH="$ZDOTDIR/.zsh.d/bin:$PATH"
 
 if ! [ -t 0 ]; then


### PR DESCRIPTION
普通の環境だと設定されていると思いますが、
特殊な環境だと設定されていないことがあります。
そういう環境向けに慣習的に追加されている`$HOME`を`$ZDOTDIR`のフォールバックとして追加しました。
